### PR TITLE
Validation by path

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "homepage": "/bridge",
   "dependencies": {
+    "@nll/datum": "^3.5.0",
     "@reduxjs/toolkit": "^1.5.1",
     "@types/draft-js": "^0.11.5",
     "@types/emscripten": "^1.39.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "rxjs": "^7.4.0",
     "styled-components": "^5.3.1",
     "ts-toolbelt": "^9.6.0",
-    "typescript": "^4.5.0-beta",
+    "typescript": "^4.5.0",
     "use-async-selector": "^0.2.7",
     "uuid-tool": "^2.0.3"
   },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "idb": "^6.1.5",
     "io-ts": "^2.2.16",
     "io-ts-types": "^0.5.16",
+    "logic-solver": "^2.0.1",
     "monocle-ts": "^2.3.11",
     "object-hash": "^2.2.0",
     "proxy-memoize": "^0.3.7",

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -22,8 +22,8 @@ const getDescriptorFromContentBlock = (x: ContentBlock): BlockKeyDescriptor & Bl
 })
 
 const eqContentBlock = monoid.concatAll(eq.getMonoid<ContentBlock>())([
-  eq.contramap((b: ContentBlock) => b.getKey())(string.Eq),
-  eq.contramap((b: ContentBlock) => b.getText())(string.Eq)
+  pipe(string.Eq, eq.contramap(b => b.getKey())),
+  pipe(string.Eq, eq.contramap(b => b.getText()))
 ])
 const getBlocks = (editorState: EditorState) => pipe(
   editorState.getCurrentContent().getBlocksAsArray(),

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -12,7 +12,7 @@ import { BlockItem, BlockKeyDescriptor, cacheSystemConstraints, removeConstraint
 
 const EditorDiv = styled.div `
   font-family: Cascadia Code, Consolas, monospace;
-  font-size: 0.8em;
+  font-size: 1em;
 `
 
 const getDescriptorFromContentBlock = (x: ContentBlock): BlockKeyDescriptor & BlockItem => ({

--- a/src/components/Errors.tsx
+++ b/src/components/Errors.tsx
@@ -70,7 +70,7 @@ interface ErrorGridProps {
 }
 export const ErrorGrid = ({ errors }: ErrorGridProps) =>
   <GridContainer>
-    {errors.map(({ bid, path, errors }) => 
+    {errors.filter(e => e.errors.length > 0).map(({ bid, path, errors }) => 
       <Fragment key={serializedBidPathL.get(path)}>
         <BidPath path={path} />
         <BidErrorsView bid={bid} errors={errors} />

--- a/src/components/Errors.tsx
+++ b/src/components/Errors.tsx
@@ -33,7 +33,7 @@ interface ValidationErrorProps {
 const ValidationErrorView = ({ error }: ValidationErrorProps) => {
   switch (error.type) {
     case "BidsOutOfOrder": return <span>Bids <BidView bid={error.left.bid} /> and <BidView bid={error.right.bid} /> out of order</span>
-    case "SAT": return <span>Path has no solution: <BidPath path={error.path} /></span>
+    // case "SAT": return <span>Path has no solution: <BidPath path={error.path} /></span>
     // case "NoPrimarySuitDefined": return <span>No primary suit defined for secondary suit {error.constraint.suit}</span>
     // case "PrimarySuitAlreadyDefined": return <span>Primary suit has already been defined</span>
     // case "SamePrimaryAndSecondarySuit": return <span>Primary and secondary suits cannot be the same</span>
@@ -45,7 +45,7 @@ const ValidationErrorView = ({ error }: ValidationErrorProps) => {
     // case "SpecificShapeInvalid": return <span>Specific shape {error.constraint.suits.S}{error.constraint.suits.H}{error.constraint.suits.D}{error.constraint.suits.C} is invalid</span>
     // case "AnyShapeInvalid": return <span>Shape {pipe(error.constraint.counts, RA.reduce("", (cur, c) => cur + c))} is invalid</span>
     // case "IllegalContextModification": return <span>Cannot modify the context under a disjunction or negation</span>
-    default: return assertUnreachable(error)
+    // default: return assertUnreachable(error)
   }
 }
 

--- a/src/components/Errors.tsx
+++ b/src/components/Errors.tsx
@@ -33,17 +33,18 @@ interface ValidationErrorProps {
 const ValidationErrorView = ({ error }: ValidationErrorProps) => {
   switch (error.type) {
     case "BidsOutOfOrder": return <span>Bids <BidView bid={error.left.bid} /> and <BidView bid={error.right.bid} /> out of order</span>
-    case "NoPrimarySuitDefined": return <span>No primary suit defined for secondary suit {error.constraint.suit}</span>
-    case "PrimarySuitAlreadyDefined": return <span>Primary suit has already been defined</span>
-    case "SamePrimaryAndSecondarySuit": return <span>Primary and secondary suits cannot be the same</span>
-    case "TrumpSuitAlreadyDefined": return <span>Trump suit has already been defined</span>
-    case "NoBidDefinedButStillForcing": return <span>Bid is forcing, but no response is defined</span>
-    case "PassWhileForcing": return <span>Previous bid is forcing, but a pass was bid</span>
-    case "SuitRangeInvalid": return <span>Suit {error.constraint.suit} range {error.constraint.min}, {error.constraint.max} is invalid</span>
-    case "PointRangeInvalid": return <span>Point range {error.constraint.min}, {error.constraint.max} is invalid </span>
-    case "SpecificShapeInvalid": return <span>Specific shape {error.constraint.suits.S}{error.constraint.suits.H}{error.constraint.suits.D}{error.constraint.suits.C} is invalid</span>
-    case "AnyShapeInvalid": return <span>Shape {pipe(error.constraint.counts, RA.reduce("", (cur, c) => cur + c))} is invalid</span>
-    case "IllegalContextModification": return <span>Cannot modify the context under a disjunction or negation</span>
+    case "SAT": return <span>Path has no solution: <BidPath path={error.path} /></span>
+    // case "NoPrimarySuitDefined": return <span>No primary suit defined for secondary suit {error.constraint.suit}</span>
+    // case "PrimarySuitAlreadyDefined": return <span>Primary suit has already been defined</span>
+    // case "SamePrimaryAndSecondarySuit": return <span>Primary and secondary suits cannot be the same</span>
+    // case "TrumpSuitAlreadyDefined": return <span>Trump suit has already been defined</span>
+    // case "NoBidDefinedButStillForcing": return <span>Bid is forcing, but no response is defined</span>
+    // case "PassWhileForcing": return <span>Previous bid is forcing, but a pass was bid</span>
+    // case "SuitRangeInvalid": return <span>Suit {error.constraint.suit} range {error.constraint.min}, {error.constraint.max} is invalid</span>
+    // case "PointRangeInvalid": return <span>Point range {error.constraint.min}, {error.constraint.max} is invalid </span>
+    // case "SpecificShapeInvalid": return <span>Specific shape {error.constraint.suits.S}{error.constraint.suits.H}{error.constraint.suits.D}{error.constraint.suits.C} is invalid</span>
+    // case "AnyShapeInvalid": return <span>Shape {pipe(error.constraint.counts, RA.reduce("", (cur, c) => cur + c))} is invalid</span>
+    // case "IllegalContextModification": return <span>Cannot modify the context under a disjunction or negation</span>
     default: return assertUnreachable(error)
   }
 }

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -1,3 +1,6 @@
+import { readonlyArray, readonlyRecord, readonlyTuple } from 'fp-ts';
+import { flow } from 'fp-ts/lib/function';
+
 export function* permute<T>(values: ReadonlyArray<T>) {
   const permutation = Array.from(values)
   var length = permutation.length,
@@ -20,3 +23,5 @@ export function* permute<T>(values: ReadonlyArray<T>) {
     }
   }
 }
+
+export const values = flow(readonlyRecord.toReadonlyArray, readonlyArray.map(readonlyTuple.snd))

--- a/src/lib/array.ts
+++ b/src/lib/array.ts
@@ -1,0 +1,22 @@
+export function* permute<T>(values: ReadonlyArray<T>) {
+  const permutation = Array.from(values)
+  var length = permutation.length,
+      c = Array(length).fill(0),
+      i = 1, k, p;
+
+  yield permutation.slice();
+  while (i < length) {
+    if (c[i] < i) {
+      k = i % 2 && c[i];
+      p = permutation[i];
+      permutation[i] = permutation[k];
+      permutation[k] = p;
+      ++c[i];
+      i = 1;
+      yield permutation.slice();
+    } else {
+      c[i] = 0;
+      ++i;
+    }
+  }
+}

--- a/src/lib/gen.ts
+++ b/src/lib/gen.ts
@@ -1,0 +1,8 @@
+export function* alternate<A>(opener: A, responder: A) {
+  while (true) { yield opener; yield responder }
+}
+
+export const unfold = (length: number) => <A>(g: Generator<A>) : readonly A[] => {
+  const val = g.next()
+  return val.done || length === 0 ? [] : [val.value, ...unfold(length - 1)(g)]
+}

--- a/src/lib/gen.ts
+++ b/src/lib/gen.ts
@@ -6,3 +6,14 @@ export const unfold = (length: number) => <A>(g: Generator<A>) : readonly A[] =>
   const val = g.next()
   return val.done || length === 0 ? [] : [val.value, ...unfold(length - 1)(g)]
 }
+
+export function* take<T>(generator: Generator<T>, n: number) {
+  for (var i = 0; i < n; i++) {
+    let v = generator.next()
+    if (!v.done) {
+      yield v.value
+    } else {
+      break
+    }
+  }
+}

--- a/src/model/constraints.spec.ts
+++ b/src/model/constraints.spec.ts
@@ -12,7 +12,7 @@ import { getForestFromLeafPaths, Path } from './system';
 import { Constraint, satisfies } from './system/core';
 import { expandForest, SyntacticBid } from './system/expander';
 import { pathIsSound } from './system/sat';
-import { validateTree } from './system/validation';
+import { validateForest } from './system/validation';
 
 const expandSingleSyntacticBid = (bid: SyntacticBid) =>
   pipe(bid,
@@ -104,7 +104,7 @@ describe('expansion path validation', () => {
         test("expands", () => {
           expect(pipe(value,
             expandSingleSyntacticBidPath,
-            x => TH.getChain(semigroup.first<unknown>()).chain(x, validateTree),
+            x => TH.getChain(semigroup.first<unknown>()).chain(x, validateForest),
             TH.isRight)).toEqual(expected)
         })
       })

--- a/src/model/system/core.ts
+++ b/src/model/system/core.ts
@@ -87,18 +87,18 @@ export interface ConstraintSpecificShape {
   suits: SpecificShape
 }
 
-interface ConstraintResponse {
-  type: "ForceOneRound" | "ForceGame" | "ForceSlam"
-}
+// interface ConstraintResponse {
+//   type: "ForceOneRound" | "ForceGame" | "ForceSlam"
+// }
 
-interface ConstraintRelayResponse {
-  type: "Relay"
-  bid: ContractBid
-}
+// interface ConstraintRelayResponse {
+//   type: "Relay"
+//   bid: ContractBid
+// }
 
-export type ConstraintForce =
-    ConstraintResponse
-  | ConstraintRelayResponse
+// export type ConstraintForce =
+//     ConstraintResponse
+//   | ConstraintRelayResponse
 
 export type Constraint =
   | ConstraintConstant
@@ -114,7 +114,7 @@ export type Constraint =
   | ConstraintSuitTop
   | ConstraintAnyShape
   | ConstraintSpecificShape
-  | ConstraintForce
+  // | ConstraintForce
 
   /* eslint-disable @typescript-eslint/no-unused-vars */
 const predFalse : P.Predicate<Hand> = constFalse
@@ -212,10 +212,10 @@ const contextualConstraintTypes = [
   "Conjunction",
   "Disjunction",
   "Negation",
-  "ForceOneRound",
-  "ForceGame",
-  "ForceSlam",
-  "Relay",
+  // "ForceOneRound",
+  // "ForceGame",
+  // "ForceSlam",
+  // "Relay",
   "SuitPrimary",
   "SuitSecondary",
   "SetTrump"
@@ -313,14 +313,14 @@ export const rotateContexts = <PL, PT, X extends { players: RR.ReadonlyRecord<Re
 export interface BidContext {
   bid: Bid,
   path: ReadonlyArray<Bid>
-  force: O.Option<ConstraintForce>
+  // force: O.Option<ConstraintForce>
   players: RR.ReadonlyRecord<RelativePlayer, PlayerContext>
   partnerships: RR.ReadonlyRecord<RelativePartnership, PartnershipContext>
 }
 export const zeroContext : BidContext = {
   bid: {} as Bid,
   path: [],
-  force: O.none,
+  // force: O.none,
   players: pipe(relativePlayers, RA.map(p => [p, zeroPlayerContext] as const), RR.fromFoldable(semigroup.first<PlayerContext>(), RA.Foldable)),
   partnerships: pipe(relativePartnerships, RA.map(p => [p, zeroPartnershipContext] as const), RR.fromFoldable(semigroup.first<PartnershipContext>(), RA.Foldable)),
 }
@@ -329,11 +329,11 @@ export const zeroContext : BidContext = {
 export const contextL = Lens.fromProp<BidContext>()
 export const bidL = contextL('bid')
 export const pathL = contextL('path')
-export const forceL = contextL('force')
+// export const forceL = contextL('force')
 export const playersL = contextL('players')
 export const partnershipsL = contextL('partnerships')
 export const contextO = Optional.fromOptionProp<BidContext>()
-export const forceO = contextO('force')
+// export const forceO = contextO('force')
 export const playerContextA = new At<BidContext, RelativePlayer, PlayerContext>(player =>
   new Lens(
     flow(playersL.get, p => p[player]),
@@ -364,13 +364,13 @@ const satisfiesContextual = (recur: SatisfiesS<BidContext, Constraint, Hand>) : 
       case "Negation": 
         return pipe(c.constraint, ofS, recur, S.map(P.not))
         
-      case "ForceOneRound":
-      case "ForceGame":
-      case "ForceSlam":
-      case "Relay":
-        return pipe(
-          S.modify<BidContext>(forceL.set(O.some(c))),
-          S.map(() => constTrue))
+      // case "ForceOneRound":
+      // case "ForceGame":
+      // case "ForceSlam":
+      // case "Relay":
+      //   return pipe(
+      //     S.modify<BidContext>(forceL.set(O.some(c))),
+      //     S.map(() => constTrue))
 
       case "SuitPrimary":
         return pipe(

--- a/src/model/system/core.ts
+++ b/src/model/system/core.ts
@@ -1,7 +1,4 @@
-import {
-    either as E, endomorphism, eq, monoid, number, option as O, optionT, ord, predicate as P, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, readonlySet, readonlyTuple,
-    record, semigroup, state as S, string
-} from 'fp-ts';
+import { either as E, endomorphism, eq, monoid, number, option as O, optionT, ord, predicate as P, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, readonlySet, readonlyTuple, record, semigroup, state as S, string } from 'fp-ts';
 import { eqStrict } from 'fp-ts/lib/Eq';
 import { apply, constant, constFalse, constTrue, flow, identity, pipe } from 'fp-ts/lib/function';
 import { At, Lens, Optional } from 'monocle-ts';
@@ -181,7 +178,7 @@ const suitSecondary = (secondarySuit: Suit) => (primarySuit: Suit) =>
     RA.filter(({ suit, otherSuit }) => !eqSuit.equals(suit, otherSuit)),
     RA.map(({ suit, otherSuit }) => suitCompare(">")(suit, otherSuit)),
     RA.concat([
-      isSuitRange({ min: 5, max: 13 })(secondarySuit),
+      isSuitRange({ min: 4, max: 13 })(secondarySuit),
       suitCompare(">=")(primarySuit, secondarySuit)
     ]),
     forall)

--- a/src/model/system/sat.ts
+++ b/src/model/system/sat.ts
@@ -1,0 +1,217 @@
+import {
+    either as E, eq, foldable, monoid, number, optionT, ord, predicate as P, reader as R, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, readonlySet, readonlyTuple, record,
+    semigroup, state as S, string
+} from 'fp-ts';
+import { sequenceT } from 'fp-ts/lib/Apply';
+import { apply, flow, identity, pipe } from 'fp-ts/lib/function';
+import { HKT, Kind, URIS, URItoKind } from 'fp-ts/lib/HKT';
+import * as Logic from 'logic-solver';
+import * as At from 'monocle-ts/lib/At';
+import * as Lens from 'monocle-ts/lib/Lens';
+
+import { numberTypeAnnotation } from '@babel/types';
+
+import { assertUnreachable } from '../../lib';
+import { permute } from '../../lib/array';
+import { Suit, suits } from '../deck';
+import { AnyShape, SpecificShape } from '../evaluation';
+import { BidContext, Constraint, ConstraintForce, RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, SuitComparisonOperator } from './core';
+
+const getForcingBits = (force: ConstraintForce): Logic.Bits => {
+  switch (force.type) {
+    // 0 for unspecified
+    case "ForceOneRound": return Logic.constantBits(1)
+    case "ForceGame": return Logic.constantBits(2)
+    case "ForceSlam": return Logic.constantBits(3)
+    case "Relay": return Logic.constantBits(4)
+  }
+}
+
+const getSuitBits = (suit: Suit): Logic.Bits =>
+  pipe(suits.indexOf(suit) + 1, Logic.constantBits) // 0-4, 0 = none
+
+const range = (min: number, max: number) => (bits: Logic.Bits) =>
+  Logic.and(
+    Logic.greaterThanOrEqual(bits, Logic.constantBits(min)),
+    Logic.lessThanOrEqual(bits, Logic.constantBits(max)))
+
+const countsTo13 = <F extends URIS>(f: foldable.Foldable1<F>) => (fa: Kind<F, number>) =>
+  pipe(
+    f.foldMap(number.MonoidSum)(fa, identity),
+    b => b === 13 ? Logic.TRUE : Logic.FALSE)
+
+const andAlso = (also: Logic.Formula) => (...formulas: readonly Logic.Formula[]) => 
+  Logic.and(also, ...formulas)
+
+const getComparer = (op: SuitComparisonOperator) => {
+  switch (op) {
+    case "<" : return Logic.lessThan
+    case "<=": return Logic.lessThanOrEqual
+    case "=" : return Logic.equalBits
+    case ">=": return Logic.greaterThanOrEqual
+    case ">" : return Logic.greaterThan
+    default  : return assertUnreachable(op)
+  }
+}
+
+interface SuitContext {
+  range: Logic.Bits
+  top: Logic.Bits
+}
+const getZeroSuitContext = (prefix: Logic.Term): SuitContext => ({
+  range: Logic.variableBits(prefix + ".range", 5),
+  top: Logic.variableBits(prefix + ".top", 3)
+})
+const suitContextL = Lens.id<SuitContext>()
+const suitRangeL = pipe(suitContextL, Lens.prop('range'))
+const suitTopL = pipe(suitContextL, Lens.prop('top'))
+
+interface PlayerContext {
+  hcpRange: Logic.Bits
+  primarySuit: Logic.Bits
+  secondarySuit: Logic.Bits
+  suits: RR.ReadonlyRecord<Suit, SuitContext>
+}
+const getZeroPlayerContext = (prefix: Logic.Term): PlayerContext => ({
+  hcpRange: Logic.variableBits(prefix + ".hcp", 6),
+  primarySuit: Logic.variableBits(prefix + ".primary", 3), 
+  secondarySuit: Logic.variableBits(prefix + ".secondary", 3),
+  suits: pipe(suits, RA.mapWithIndex((i, s) => [s, getZeroSuitContext(i)] as const), RR.fromFoldable(semigroup.first<SuitContext>(), RA.Foldable)),
+})
+const playerContextL = Lens.id<PlayerContext>()
+const hcpRangeL = pipe(playerContextL, Lens.prop('hcpRange'))
+const primarySuitL = pipe(playerContextL, Lens.prop('primarySuit'))
+const secondarySuitL = pipe(playerContextL, Lens.prop('secondarySuit'))
+const suitsL = pipe(playerContextL, Lens.prop('suits'))
+const suitsA = At.at<PlayerContext, Suit, SuitContext>(i =>
+  Lens.lens(
+    flow(suitsL.get, p => p[i]),
+    p => context => pipe(context, suitsL.get, RR.upsertAt(i, p), suitsL.set, apply(context))))
+
+const suitsMatch = (playerSuits: PlayerContext["suits"]) => (pattern: SpecificShape) =>
+  pipe(playerSuits,
+    RR.toReadonlyArray,
+    RA.map(([i, s0]) => pipe(pattern[i], Logic.constantBits, s1 => Logic.equalBits(s0, s1))),
+    Logic.and)
+
+interface PartnershipContext {
+  trumpSuit: Logic.Bits
+}
+const getZeroPartnershipContext = (prefix: Logic.Term): PartnershipContext => ({
+  trumpSuit: Logic.variableBits(prefix + ".trump", 3),
+})
+const partnershipContextL = Lens.id<PartnershipContext>()
+const trumpSuitL = pipe(partnershipContextL, Lens.prop('trumpSuit'))
+
+interface SATContext {
+  force: Logic.Bits
+  players: RR.ReadonlyRecord<RelativePlayer, PlayerContext>
+  partnerships: RR.ReadonlyRecord<RelativePartnership, PartnershipContext>
+}
+const zeroSATContext: SATContext = {
+  force: Logic.constantBits(0),
+  players: pipe(relativePlayers, RA.mapWithIndex((i, p) => [p, getZeroPlayerContext(i)] as const), RR.fromFoldable(semigroup.first<PlayerContext>(), RA.Foldable)),
+  partnerships: pipe(relativePartnerships, RA.mapWithIndex((i, p) => [p, getZeroPartnershipContext(i)] as const), RR.fromFoldable(semigroup.first<PartnershipContext>(), RA.Foldable))
+}
+const contextL = Lens.id<SATContext>()
+const forceL = pipe(contextL, Lens.prop('force'))
+const playersL = pipe(contextL, Lens.prop('players'))
+const partnershipsL = pipe(contextL, Lens.prop('partnerships'))
+const playersA = At.at<SATContext, RelativePlayer, PlayerContext>(i =>
+  Lens.lens(
+    flow(playersL.get, p => p[i]),
+    p => context => pipe(context, playersL.get, RR.upsertAt(i, p), playersL.set, apply(context))))
+const partnershipsA = At.at<SATContext, RelativePartnership, PartnershipContext>(i =>
+  Lens.lens(
+    flow(partnershipsL.get, p => p[i]),
+    p => context => pipe(context, partnershipsL.get, RR.upsertAt(i, p), partnershipsL.set, apply(context))))
+
+const toSAT = (c: Constraint): R.Reader<SATContext, Logic.Formula> => {
+  switch (c.type) {
+    case "Conjunction":
+      return pipe(c.constraints, R.traverseArray(toSAT), R.map(Logic.and))
+    case "Disjunction":
+      return pipe(c.constraints, R.traverseArray(toSAT), R.map(Logic.or))
+    case "Negation": 
+      return pipe(c.constraint, toSAT, R.map(Logic.not))
+
+    case "ForceOneRound":
+    case "ForceGame":
+    case "ForceSlam":
+    case "Relay":
+      return pipe(
+        R.asks(forceL.get),
+        R.map(f0 => pipe(c, getForcingBits, f =>
+          Logic.lessThanOrEqual(f0, f))))
+        
+    case "SuitPrimary":
+      return pipe(
+        R.asks(pipe(playersA.at("Me"), Lens.compose(primarySuitL)).get),
+        R.map(s0 => pipe(c.suit, getSuitBits, s =>
+          Logic.equalBits(s0, s))))
+    case "SuitSecondary":
+      return pipe(R.Do,
+        R.apS('p0', R.asks(pipe(playersA.at("Me"), Lens.compose(primarySuitL)).get)),
+        R.apS('s0', R.asks(pipe(playersA.at("Me"), Lens.compose(secondarySuitL)).get)),
+        R.map(({ p0, s0 }) => pipe(c.suit, getSuitBits, s =>
+          Logic.and(
+            Logic.equalBits(s0, s),
+            Logic.not(Logic.equalBits(p0, s))))))
+
+    case "SetTrump":
+      return pipe(
+        R.asks(pipe(partnershipsA.at("We"), Lens.compose(trumpSuitL)).get),
+        R.map(s0 => pipe(c.suit, getSuitBits, s =>
+          Logic.equalBits(s0, s))))
+
+    case "PointRange":
+      return pipe(
+        R.asks(pipe(playersA.at("Me"), Lens.compose(hcpRangeL)).get),
+        R.map(range(c.min, c.max)))
+    case "SuitRange":
+      return pipe(
+        R.asks(pipe(playersA.at("Me"), Lens.compose(suitsA.at(c.suit)), Lens.compose(suitRangeL)).get),
+        R.map(range(c.min, c.max)))
+
+    case "SpecificShape":
+      return pipe(
+        R.asks(pipe(playersA.at("Me"), Lens.compose(suitsL)).get),
+        R.map(flow(
+          suitsMatch,
+          apply(c.suits),
+          andAlso(pipe(c.suits, countsTo13(RR.getFoldable(ord.trivial)))))))
+
+    case "AnyShape":
+      return pipe(
+        R.asks(pipe(playersA.at("Me"), Lens.compose(suitsL)).get),
+        R.map(flow(
+          suitsMatch,
+          RA.of,
+          RA.ap(pipe(
+            Array.from(permute(c.counts)),
+            RA.map(flow(
+              shape => RA.zip(suits, shape),
+              RR.fromFoldable(semigroup.first<number>(), RA.Foldable),
+              (suits: RR.ReadonlyRecord<Suit, number>) => suits)))),
+          andAlso(pipe(c.counts, countsTo13(RA.Foldable))))))
+
+    case "SuitComparison":
+      return pipe(R.Do,
+        R.apS('s1', R.asks(pipe(playersA.at("Me"), Lens.compose(suitsA.at(c.left)), Lens.compose(suitRangeL)).get)),
+        R.apS('s2', R.asks(pipe(playersA.at("Me"), Lens.compose(suitsA.at(c.right)), Lens.compose(suitRangeL)).get)),
+        R.map(({ s1, s2 }) => getComparer(c.op)(s1, s2)))
+
+    case "Constant":
+      return R.of(Logic.TRUE)
+
+    case "SuitHonors":
+    case "SuitTop":
+      // do later
+      return R.of(Logic.TRUE)
+
+        
+    default:
+      return assertUnreachable(c)
+  }
+}
+

--- a/src/model/system/sat.ts
+++ b/src/model/system/sat.ts
@@ -4,7 +4,6 @@ import { Kind, URIS } from 'fp-ts/lib/HKT';
 import * as Logic from 'logic-solver';
 import * as At from 'monocle-ts/lib/At';
 import * as Lens from 'monocle-ts/lib/Lens';
-import memoize from 'proxy-memoize';
 
 import { assertUnreachable } from '../../lib';
 import { permute, values } from '../../lib/array';
@@ -347,7 +346,7 @@ function* allSolutions(solver: Logic.Solver) {
   }
 }
 
-export const pathIsSound = memoize((path: Path<ConstrainedBid>) => {
+export const pathIsSound = (path: Path<ConstrainedBid>) => {
   const solver = new Logic.Solver()
   const context = zeroSATContext
   solver.require(pipe(baseAssumptions, values, RA.flap(context), Logic.and))
@@ -371,6 +370,4 @@ export const pathIsSound = memoize((path: Path<ConstrainedBid>) => {
         return constVoid()
       }))),
     S.evaluate(context))
-}, {
-  size: 1000
-})
+}

--- a/src/model/system/sat.ts
+++ b/src/model/system/sat.ts
@@ -7,9 +7,10 @@ import * as Lens from 'monocle-ts/lib/Lens';
 import memoize from 'proxy-memoize';
 
 import { assertUnreachable } from '../../lib';
-import { permute } from '../../lib/array';
+import { permute, values } from '../../lib/array';
 import { take } from '../../lib/gen';
 import { get } from '../../lib/object';
+import { Bid } from '../bridge';
 import { eqSuit, Suit, suits } from '../deck';
 import { SpecificShape } from '../evaluation';
 import { Path } from '../system';
@@ -256,8 +257,6 @@ const sat = (c: Constraint): R.Reader<SATContext, Logic.Formula> => {
   }
 }
 
-const values = flow(RR.toReadonlyArray, RA.map(RT.snd))
-
 const stateFromReader = <X, A>(r: R.Reader<X, A>): S.State<X, A> =>
   c => [r(c), c]
 
@@ -360,7 +359,7 @@ export const pathIsSound = memoize((path: Path<ConstrainedBid>) => {
     RNEA.traverseWithIndex(S.Applicative)((i, info) => pipe(
       info.constraint,
       sat,
-      R.map(flow(solve, E.fromOption(() => pipe(path, RNEA.splitAt(i), RT.fst) as Path<ConstrainedBid>))),
+      R.map(flow(solve, E.fromOption(() => pipe(path, RNEA.splitAt(i), RT.fst, RNEA.map(get('bid'))) as Path<Bid>))),
       stateFromReader,
       S.apFirst(S.modify(rotateContexts)))),
     S.map(flow(

--- a/src/model/system/sat.ts
+++ b/src/model/system/sat.ts
@@ -11,17 +11,17 @@ import { permute } from '../../lib/array';
 import { eqSuit, Suit, suits } from '../deck';
 import { SpecificShape } from '../evaluation';
 import { Path } from '../system';
-import { ConstrainedBid, Constraint, ConstraintForce, RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, rotateContexts, SuitComparisonOperator } from './core';
+import { ConstrainedBid, Constraint, RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, rotateContexts, SuitComparisonOperator } from './core';
 
-const getForcingBits = (force: ConstraintForce): Logic.Bits => {
-  switch (force.type) {
-    // 0 for unspecified
-    case "ForceOneRound": return Logic.constantBits(1)
-    case "ForceGame": return Logic.constantBits(2)
-    case "ForceSlam": return Logic.constantBits(3)
-    case "Relay": return Logic.constantBits(4)
-  }
-}
+// const getForcingBits = (force: ConstraintForce): Logic.Bits => {
+//   switch (force.type) {
+//     // 0 for unspecified
+//     case "ForceOneRound": return Logic.constantBits(1)
+//     case "ForceGame": return Logic.constantBits(2)
+//     case "ForceSlam": return Logic.constantBits(3)
+//     case "Relay": return Logic.constantBits(4)
+//   }
+// }
 
 const getSuitBits = (suit: Suit): Logic.Bits =>
   pipe(suits.indexOf(suit) + 1, Logic.constantBits) // 0-4, 0 = none
@@ -125,17 +125,17 @@ const partnershipContextL = Lens.id<PartnershipContext>()
 const trumpSuitL = pipe(partnershipContextL, Lens.prop('trumpSuit'))
 
 interface SATContext {
-  force: Logic.Bits
+  // force: Logic.Bits
   players: RR.ReadonlyRecord<RelativePlayer, PlayerContext>
   partnerships: RR.ReadonlyRecord<RelativePartnership, PartnershipContext>
 }
 const zeroSATContext: SATContext = {
-  force: Logic.constantBits(0),
+  // force: Logic.constantBits(0),
   players: pipe(relativePlayers, RA.mapWithIndex((i, p) => [p, getZeroPlayerContext(i)] as const), RR.fromFoldable(semigroup.first<PlayerContext>(), RA.Foldable)),
   partnerships: pipe(relativePartnerships, RA.map(p => [p, getZeroPartnershipContext(p)] as const), RR.fromFoldable(semigroup.first<PartnershipContext>(), RA.Foldable))
 }
 const contextL = Lens.id<SATContext>()
-const forceL = pipe(contextL, Lens.prop('force'))
+// const forceL = pipe(contextL, Lens.prop('force'))
 const playersL = pipe(contextL, Lens.prop('players'))
 const partnershipsL = pipe(contextL, Lens.prop('partnerships'))
 const playersA = At.at<SATContext, RelativePlayer, PlayerContext>(i =>
@@ -156,14 +156,14 @@ const sat = (c: Constraint): R.Reader<SATContext, Logic.Formula> => {
     case "Negation": 
       return pipe(c.constraint, sat, R.map(Logic.not))
 
-    case "ForceOneRound":
-    case "ForceGame":
-    case "ForceSlam":
-    case "Relay":
-      return pipe(
-        R.asks(forceL.get),
-        R.map(f0 => pipe(c, getForcingBits, f =>
-          Logic.lessThanOrEqual(f0, f))))
+    // case "ForceOneRound":
+    // case "ForceGame":
+    // case "ForceSlam":
+    // case "Relay":
+    //   return pipe(
+    //     R.asks(forceL.get),
+    //     R.map(f0 => pipe(c, getForcingBits, f =>
+    //       Logic.lessThanOrEqual(f0, f))))
         
     case "SuitPrimary":
       return pipe(

--- a/src/model/system/sat.ts
+++ b/src/model/system/sat.ts
@@ -1,23 +1,16 @@
-import {
-    either as E, eq, foldable, monoid, number, option as O, optionT, ord, predicate as P, reader as R, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, readonlySet,
-    readonlyTuple, record, semigroup, state as S, string
-} from 'fp-ts';
-import { sequenceT } from 'fp-ts/lib/Apply';
+import { either as E, foldable, number, option as O, ord, reader as R, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, semigroup, state as S } from 'fp-ts';
 import { apply, constVoid, flow, identity, pipe } from 'fp-ts/lib/function';
-import { HKT, Kind, URIS, URItoKind } from 'fp-ts/lib/HKT';
+import { Kind, URIS } from 'fp-ts/lib/HKT';
 import * as Logic from 'logic-solver';
 import * as At from 'monocle-ts/lib/At';
 import * as Lens from 'monocle-ts/lib/Lens';
 
-import { numberTypeAnnotation } from '@babel/types';
-
 import { assertUnreachable } from '../../lib';
 import { permute } from '../../lib/array';
-import { Bid } from '../bridge';
 import { Suit, suits } from '../deck';
-import { AnyShape, SpecificShape } from '../evaluation';
+import { SpecificShape } from '../evaluation';
 import { Path } from '../system';
-import { BidContext, ConstrainedBid, Constraint, ConstraintForce, RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, rotateRecord, SuitComparisonOperator } from './core';
+import { ConstrainedBid, Constraint, ConstraintForce, RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, rotateRecord, SuitComparisonOperator } from './core';
 
 const getForcingBits = (force: ConstraintForce): Logic.Bits => {
   switch (force.type) {
@@ -196,6 +189,7 @@ const sat = (c: Constraint): R.Reader<SATContext, Logic.Formula> => {
               shape => RA.zip(suits, shape),
               RR.fromFoldable(semigroup.first<number>(), RA.Foldable),
               (suits: RR.ReadonlyRecord<Suit, number>) => suits)))),
+          Logic.or,
           andAlso(pipe(c.counts, countsTo13(RA.Foldable))))))
 
     case "SuitComparison":
@@ -252,6 +246,6 @@ export const pathIsSound = (path: Path<ConstrainedBid>) => {
       S.apFirst(rotateContexts))),
     S.map(flow(
       RNEA.sequence(E.Applicative),
-      E.map(() => allSolutions(solver)))),
+      E.map(constVoid))),
     S.evaluate(zeroSATContext))
 }

--- a/src/model/system/satisfaction.ts
+++ b/src/model/system/satisfaction.ts
@@ -4,18 +4,18 @@ import { identity, pipe } from 'fp-ts/lib/function';
 import * as Gen from '../../lib/gen';
 import { eqBid } from '../bridge';
 import { Hand } from '../deck';
-import { BidContext, bidL, ConstrainedBid, Constraint, constraintTrue, forceO, ofS, pathL, rotateContexts, satisfiesS, zeroContext } from './core';
+import { BidContext, bidL, ConstrainedBid, Constraint, constraintTrue, ofS, pathL, rotateContexts, satisfiesS, zeroContext } from './core';
 
-const specialRelayCase = (s: S.State<BidContext, Constraint>) =>
-  pipe(s,
-    S.bindTo('constraint'),
-    S.apS('force', S.gets(forceO.getOption)),
-    S.apS('bid', S.gets(bidL.get)),
-    S.map(info =>
-      pipe(info.force,
-        O.chain(O.fromPredicate(force =>
-          info.constraint.type === "Constant" && !info.constraint.value && force.type === "Relay" && eqBid.equals(force.bid, info.bid))),
-        O.fold(() => info.constraint, constraintTrue))))
+// const specialRelayCase = (s: S.State<BidContext, Constraint>) =>
+//   pipe(s,
+//     S.bindTo('constraint'),
+//     S.apS('force', S.gets(forceO.getOption)),
+//     S.apS('bid', S.gets(bidL.get)),
+//     S.map(info =>
+//       pipe(info.force,
+//         O.chain(O.fromPredicate(force =>
+//           info.constraint.type === "Constant" && !info.constraint.value && force.type === "Relay" && eqBid.equals(force.bid, info.bid))),
+//         O.fold(() => info.constraint, constraintTrue))))
 
 export const satisfiesPath = (opener: Hand, responder: Hand) => (path: RNEA.ReadonlyNonEmptyArray<ConstrainedBid>) =>
   pipe(
@@ -26,7 +26,7 @@ export const satisfiesPath = (opener: Hand, responder: Hand) => (path: RNEA.Read
       pipe(
         ofS(info.constraint),
         S.chainFirst(() => S.modify(bidL.set(info.bid))),
-        specialRelayCase,
+        // specialRelayCase,
         satisfiesS,
         S.flap(hand),
         S.apFirst(S.modify(rotateContexts)),

--- a/src/model/system/satisfaction.ts
+++ b/src/model/system/satisfaction.ts
@@ -1,20 +1,12 @@
 import { boolean, option as O, readonlyArray as RA, readonlyNonEmptyArray as RNEA, state as S } from 'fp-ts';
 import { constVoid, flow, identity, pipe } from 'fp-ts/lib/function';
 
+import * as Gen from '../../lib/gen';
 import { eqBid } from '../bridge';
 import { Hand } from '../deck';
-import { BidContext, bidL, ConstrainedBid, Constraint, constraintTrue, forceO, ofS, partnershipsL, pathL, playersL, relativePartnerships, relativePlayers, rotateRecord, satisfiesS, zeroContext } from './core';
-
-module Gen {
-  export function* alternate<A>(opener: A, responder: A) {
-    while (true) { yield opener; yield responder }
-  }
-
-  export const unfold = (length: number) => <A>(g: Generator<A>) : readonly A[] => {
-    const val = g.next()
-    return val.done || length === 0 ? [] : [val.value, ...unfold(length - 1)(g)]
-  }
-}
+import {
+    BidContext, bidL, ConstrainedBid, Constraint, constraintTrue, forceO, ofS, partnershipsL, pathL, playersL, relativePartnerships, relativePlayers, rotateRecord, satisfiesS, zeroContext
+} from './core';
 
 const specialRelayCase = (s: S.State<BidContext, Constraint>) =>
   pipe(s,

--- a/src/model/system/validation.ts
+++ b/src/model/system/validation.ts
@@ -183,10 +183,10 @@ const forestIsSound = (tree: Forest<ConstrainedBid>) : SystemValidation =>
     getAllLeafPaths,
     RA.traverse(E.Applicative)(flow(
       pathIsSound,
-      E.mapLeft((path): SystemValidationError => ({ type: "SAT", path: path.map(b => b.bid) })))),
+      E.mapLeft((path): SystemValidationError => ({ type: "SAT", path })))),
     E.map(constVoid))
 
 export const validateTree = (forest: Forest<ConstrainedBid>) =>
-  pipe([forestSorted, forestIsSound],
+  pipe([forestSorted], //forestIsSound],
     RA.traverse(E.Applicative)(apply(forest)),
     E.map(constVoid))

--- a/src/model/system/validation.ts
+++ b/src/model/system/validation.ts
@@ -1,20 +1,16 @@
 import { either as E, ord, readonlyArray as RA, readonlyNonEmptyArray as RNEA } from 'fp-ts';
-import { apply, constVoid, flow, pipe } from 'fp-ts/lib/function';
+import { apply, constVoid, pipe } from 'fp-ts/lib/function';
 
 import { Bid } from '../bridge';
 import { Forest, getAllLeafPaths, Path } from '../system';
 import { ConstrainedBid, ordConstrainedBid } from './core';
-import { pathIsSound } from './sat';
 
 interface SystemValidationErrorBidsOutOfOrder {
   type: "BidsOutOfOrder"
   left: ConstrainedBid
   right: ConstrainedBid
 }
-interface SystemValidationErrorSAT {
-  type: "SAT"
-  // path: Path<ConstrainedBid>
-}
+
 // interface SystemValidationErrorPrimarySuitAlreadyDefined {
 //   type: "PrimarySuitAlreadyDefined"
 //   constraint: ConstraintSuitPrimary
@@ -74,8 +70,7 @@ interface SystemValidationErrorSAT {
 export type SystemValidationError =
   
   // ( SystemValidationBidError
-  (| SystemValidationErrorBidsOutOfOrder
-  | SystemValidationErrorSAT)
+  (| SystemValidationErrorBidsOutOfOrder )
   // | SystemValidationErrorPassWhileForcing
   // | SystemValidationErrorNoBidDefinedButStillForcing)
   & { path: ReadonlyArray<Bid> }
@@ -178,15 +173,15 @@ const forestSorted = (tree: Forest<ConstrainedBid>) =>
 //     eitherT.chain(S.Monad)(() => checkFinal),
 //     S.evaluate(zeroValidationContext))
 
-const forestIsSound = (tree: Forest<ConstrainedBid>) : SystemValidation =>
-  pipe(tree,
-    getAllLeafPaths,
-    RA.traverse(E.Applicative)(flow(
-      pathIsSound,
-      E.mapLeft((path): SystemValidationError => ({ type: "SAT", path })))),
-    E.map(constVoid))
+// const forestIsSound = (tree: Forest<ConstrainedBid>) : SystemValidation =>
+//   pipe(tree,
+//     getAllLeafPaths,
+//     RA.traverse(E.Applicative)(flow(
+//       pathIsSound,
+//       E.mapLeft((path): SystemValidationError => ({ type: "SAT", path })))),
+//     E.map(constVoid))
 
-export const validateTree = (forest: Forest<ConstrainedBid>) =>
+export const validateForest = (forest: Forest<ConstrainedBid>) =>
   pipe([forestSorted], //forestIsSound],
     RA.traverse(E.Applicative)(apply(forest)),
     E.map(constVoid))

--- a/src/model/system/validation.ts
+++ b/src/model/system/validation.ts
@@ -1,13 +1,9 @@
-import { boolean, either as E, eitherT, option as O, optionT, ord, readonlyArray as RA, readonlyNonEmptyArray as RNEA, state as S } from 'fp-ts';
+import { either as E, ord, readonlyArray as RA, readonlyNonEmptyArray as RNEA } from 'fp-ts';
 import { apply, constVoid, flow, pipe } from 'fp-ts/lib/function';
 
-import { assertUnreachable } from '../../lib';
-import { Bid, isGameLevel, isSlamLevel } from '../bridge';
+import { Bid } from '../bridge';
 import { Forest, getAllLeafPaths, Path } from '../system';
-import {
-    BidContext, bidL, ConstrainedBid, ConstraintAnyShape, ConstraintForce, ConstraintPointRange, ConstraintSetTrump, ConstraintSpecificShape, ConstraintSuitPrimary, ConstraintSuitRange,
-    ConstraintSuitSecondary, forceL, forceO, ofS, ordConstrainedBid, partnershipsL, pathL, playersL, relativePartnerships, relativePlayers, rotateRecord
-} from './core';
+import { ConstrainedBid, ordConstrainedBid } from './core';
 import { pathIsSound } from './sat';
 
 interface SystemValidationErrorBidsOutOfOrder {

--- a/src/model/system/validation.ts
+++ b/src/model/system/validation.ts
@@ -1,126 +1,92 @@
-import { boolean, either as E, eitherT, number, option as O, optionT, ord, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyRecord as RR, state as S } from 'fp-ts';
-import { apply, constVoid, flow, identity, pipe } from 'fp-ts/lib/function';
-import { At, Lens, Optional } from 'monocle-ts';
+import { boolean, either as E, eitherT, option as O, optionT, ord, readonlyArray as RA, readonlyNonEmptyArray as RNEA, state as S } from 'fp-ts';
+import { apply, constVoid, flow, pipe } from 'fp-ts/lib/function';
 
 import { assertUnreachable } from '../../lib';
 import { Bid, isGameLevel, isSlamLevel } from '../bridge';
 import { Forest, getAllLeafPaths, Path } from '../system';
 import {
-    BidContext, ConstrainedBid, Constraint, ConstraintAnyShape, ConstraintForce, ConstraintPointRange, ConstraintSetTrump, ConstraintSpecificShape, ConstraintSuitPrimary, ConstraintSuitRange, ConstraintSuitSecondary, ordConstrainedBid, PartnershipContext, PlayerContext, primarySuitL,
-    RelativePartnership, relativePartnerships, RelativePlayer, relativePlayers, rotateRecord, secondarySuitL, trumpSuitL, zeroContext as zeroBidContext
+    BidContext, bidL, ConstrainedBid, ConstraintAnyShape, ConstraintForce, ConstraintPointRange, ConstraintSetTrump, ConstraintSpecificShape, ConstraintSuitPrimary, ConstraintSuitRange,
+    ConstraintSuitSecondary, forceL, forceO, ofS, ordConstrainedBid, partnershipsL, pathL, playersL, relativePartnerships, relativePlayers, rotateRecord
 } from './core';
+import { pathIsSound } from './sat';
 
 interface SystemValidationErrorBidsOutOfOrder {
   type: "BidsOutOfOrder"
   left: ConstrainedBid
   right: ConstrainedBid
 }
-interface SystemValidationErrorNoPrimarySuitDefined {
-  type: "NoPrimarySuitDefined"
-  constraint: ConstraintSuitSecondary
+interface SystemValidationErrorSAT {
+  type: "SAT"
+  // path: Path<ConstrainedBid>
 }
-interface SystemValidationErrorPrimarySuitAlreadyDefined {
-  type: "PrimarySuitAlreadyDefined"
-  constraint: ConstraintSuitPrimary
-}
-interface SystemValidationErrorSamePrimaryAndSecondarySuit {
-  type: "SamePrimaryAndSecondarySuit"
-  constraint: ConstraintSuitSecondary
-}
-interface SystemValidationErrorTrumpSuitAlreadyDefined {
-  type: "TrumpSuitAlreadyDefined"
-  constraint: ConstraintSetTrump
-}
-interface SystemValidationErrorSuitRangeInvalid {
-  type: "SuitRangeInvalid",
-  constraint: ConstraintSuitRange
-}
-interface SystemValidationErrorPointRangeInvalid {
-  type: "PointRangeInvalid",
-  constraint: ConstraintPointRange
-}
-interface SystemValidationErrorSpecificShapeInvalid {
-  type: "SpecificShapeInvalid",
-  constraint: ConstraintSpecificShape
-}
+// interface SystemValidationErrorPrimarySuitAlreadyDefined {
+//   type: "PrimarySuitAlreadyDefined"
+//   constraint: ConstraintSuitPrimary
+// }
+// interface SystemValidationErrorSamePrimaryAndSecondarySuit {
+//   type: "SamePrimaryAndSecondarySuit"
+//   constraint: ConstraintSuitSecondary
+// }
+// interface SystemValidationErrorTrumpSuitAlreadyDefined {
+//   type: "TrumpSuitAlreadyDefined"
+//   constraint: ConstraintSetTrump
+// }
+// interface SystemValidationErrorSuitRangeInvalid {
+//   type: "SuitRangeInvalid",
+//   constraint: ConstraintSuitRange
+// }
+// interface SystemValidationErrorPointRangeInvalid {
+//   type: "PointRangeInvalid",
+//   constraint: ConstraintPointRange
+// }
+// interface SystemValidationErrorSpecificShapeInvalid {
+//   type: "SpecificShapeInvalid",
+//   constraint: ConstraintSpecificShape
+// }
 
-interface SystemValidationErrorAnyShapeInvalid {
-  type: "AnyShapeInvalid",
-  constraint: ConstraintAnyShape
-}
-interface SystemValidationErrorPassWhileForcing {
-  type: "PassWhileForcing",
-  bid: Bid
-}
-interface SystemValidationErrorNoBidDefinedButStillForcing {
-  type: "NoBidDefinedButStillForcing",
-  path: ReadonlyArray<Bid>
-}
+// interface SystemValidationErrorAnyShapeInvalid {
+//   type: "AnyShapeInvalid",
+//   constraint: ConstraintAnyShape
+// }
+// interface SystemValidationErrorPassWhileForcing {
+//   type: "PassWhileForcing",
+//   bid: Bid
+// }
+// interface SystemValidationErrorNoBidDefinedButStillForcing {
+//   type: "NoBidDefinedButStillForcing",
+//   path: ReadonlyArray<Bid>
+// }
 
-interface SystemValidationErrorIllegalContextModification {
-  type: "IllegalContextModification"
-}
+// interface SystemValidationErrorIllegalContextModification {
+//   type: "IllegalContextModification"
+// }
 
-type SystemValidationBidReason =
-  | SystemValidationErrorNoPrimarySuitDefined
-  | SystemValidationErrorPrimarySuitAlreadyDefined
-  | SystemValidationErrorSamePrimaryAndSecondarySuit
-  | SystemValidationErrorTrumpSuitAlreadyDefined
-  | SystemValidationErrorSuitRangeInvalid
-  | SystemValidationErrorPointRangeInvalid
-  | SystemValidationErrorSpecificShapeInvalid
-  | SystemValidationErrorAnyShapeInvalid
-  | SystemValidationErrorIllegalContextModification
-type SystemValidationBidError = SystemValidationBidReason & {
-  bid: Bid
-}
+// type SystemValidationBidReason =
+//   | SystemValidationErrorNoPrimarySuitDefined
+//   | SystemValidationErrorPrimarySuitAlreadyDefined
+//   | SystemValidationErrorSamePrimaryAndSecondarySuit
+//   | SystemValidationErrorTrumpSuitAlreadyDefined
+//   | SystemValidationErrorSuitRangeInvalid
+//   | SystemValidationErrorPointRangeInvalid
+//   | SystemValidationErrorSpecificShapeInvalid
+//   | SystemValidationErrorAnyShapeInvalid
+//   | SystemValidationErrorIllegalContextModification
+// type SystemValidationBidError = SystemValidationBidReason & {
+//   bid: Bid
+// }
 
 export type SystemValidationError =
-  ( SystemValidationBidError
-  | SystemValidationErrorBidsOutOfOrder
-  | SystemValidationErrorPassWhileForcing
-  | SystemValidationErrorNoBidDefinedButStillForcing)
+  
+  // ( SystemValidationBidError
+  (| SystemValidationErrorBidsOutOfOrder
+  | SystemValidationErrorSAT)
+  // | SystemValidationErrorPassWhileForcing
+  // | SystemValidationErrorNoBidDefinedButStillForcing)
   & { path: ReadonlyArray<Bid> }
 
-type EffectContext =
-  | "Open"
-  | "Disjunction"
-  | "Negation"
-interface ValidateContext extends BidContext {
-  effectContext: EffectContext
-}
-export const zeroValidationContext: ValidateContext = ({
-  ...zeroBidContext,
-  effectContext: "Open"
-})
-const ofS = <A>(x: A) => S.of<ValidateContext, A>(x)
-const contextL = Lens.fromProp<ValidateContext>()
-const effectContextL = contextL('effectContext')
-const bidL = contextL('bid')
-const pathL = contextL('path')
-const forceL = contextL('force')
-export const playersL = contextL('players')
-export const partnershipsL = contextL('partnerships')
-const contextO = Optional.fromOptionProp<ValidateContext>()
-const forceO = contextO('force')
-export const playerContextA = new At<ValidateContext, RelativePlayer, PlayerContext>(player =>
-  new Lens(
-    flow(playersL.get, p => p[player]),
-    p => context => pipe(context, playersL.get, RR.upsertAt(player, p), playersL.set, apply(context))))
-export const partnershipContextA = new At<ValidateContext, RelativePartnership, PartnershipContext>(partnership =>
-  new Lens(
-    flow(partnershipsL.get, p => p[partnership]),
-    p => context => pipe(context, partnershipsL.get, RR.upsertAt(partnership, p), partnershipsL.set, apply(context))))
-
 type SystemValidation = E.Either<SystemValidationError, void>
-type ValidateReasonResult = S.State<ValidateContext, E.Either<SystemValidationBidReason, void>>
-type ValidateResult = S.State<ValidateContext, SystemValidation>
-
-const effectModifyS = (setter: (context: ValidateContext) => ValidateContext): ValidateReasonResult =>
-  pipe(S.gets(effectContextL.get),
-    S.chain(x => x === "Open"
-      ? pipe(S.modify(setter), S.map(() => E.right(constVoid())))
-      : S.of(E.left({ type: "IllegalContextModification" }))))
+// type ValidateReasonResult = S.State<BidContext, E.Either<SystemValidationBidReason, void>>
+// type ValidateResult = S.State<BidContext, SystemValidation>
 
 const bidPathSorted = (path: Path<ConstrainedBid>): SystemValidation =>
   pipe(path,
@@ -138,179 +104,90 @@ const forestSorted = (tree: Forest<ConstrainedBid>) =>
     RA.traverse(E.Applicative)(bidPathSorted),
     E.map(constVoid))
 
-const validateConnectiveConstraints = (cs: ReadonlyArray<Constraint>) => (traverseContext: EffectContext) =>
-  pipe(
-    S.gets(effectContextL.get),
-    S.chain(outerContext => pipe(
-      S.modify(effectContextL.set(traverseContext)),
-      S.map(() => cs),
-      S.chain(S.traverseArray(validateS)),
-      S.map(flow(
-        RA.sequence(E.Applicative),
-        E.map(constVoid))),
-      S.apFirst(S.modify(effectContextL.set(outerContext))))))
+// const resetForce = S.modify(forceL.set(O.none))
+// const continueForce: typeof resetForce = S.of(constVoid())
+// const updateForce = (bid: Bid) => (force: ConstraintForce) => {
+//   switch (force.type) {
+//     case "ForceOneRound":
+//     case "Relay":
+//       return resetForce
+//     case "ForceGame":
+//       return isGameLevel(bid) ? resetForce : continueForce
+//     case "ForceSlam":
+//       return isSlamLevel(bid) ? resetForce : continueForce
+//     default:
+//       return assertUnreachable(force)
+//   }
+// }
 
-export const validateS = (c: Constraint): ValidateReasonResult => {
-  switch (c.type) {
-    case "Conjunction":
-      return pipe(
-        S.gets(effectContextL.get),
-        S.chain(validateConnectiveConstraints(c.constraints)))
-    case "Disjunction":
-      return validateConnectiveConstraints(c.constraints)(c.type)
-    case "Negation": 
-      return validateConnectiveConstraints(RA.of(c.constraint))(c.type)
+// const updateForceS : S.State<BidContext, void> =
+//   pipe(
+//     updateForce, ofS,
+//     S.ap(S.gets(bidL.get)),
+//     S.map(O.of),
+//     optionT.ap(S.Apply)(S.gets(forceL.get)),
+//     S.chain(O.sequence(S.Applicative)),
+//     S.map(constVoid))
 
-    case "ForceOneRound":
-    case "ForceGame":
-    case "ForceSlam":
-    case "Relay":
-      return effectModifyS(forceL.set(O.some(c)))
+// const rotateRelativeContexts : S.State<BidContext, void> =
+//   pipe(
+//     S.sequenceArray([
+//       pipe(S.gets(playersL.get), S.chain(flow(rotateRecord(relativePlayers), playersL.set, S.modify))),
+//       pipe(S.gets(partnershipsL.get), S.chain(flow(rotateRecord(relativePartnerships), partnershipsL.set, S.modify)))
+//     ]),
+//     S.map(constVoid))
 
-    case "SuitPrimary":
-      return pipe(
-        S.gets(playerContextA.at("Me").composeLens(primarySuitL).get),
-        S.chain(O.fold(
-          () => effectModifyS(playerContextA.at("Me").composeLens(primarySuitL).set(O.some(c.suit))),
-          () => ofS(E.left({ type: "PrimarySuitAlreadyDefined", constraint: c })))))
-    case "SuitSecondary":
-      return pipe(
-        effectModifyS(playerContextA.at("Me").composeLens(secondarySuitL).set(O.some(c.suit))),
-        eitherT.chain(S.Monad)(() => pipe(
-          S.gets(playerContextA.at("Me").composeLens(primarySuitL).get),
-          S.map(flow(
-            E.fromOption((): SystemValidationBidReason => ({ type: "NoPrimarySuitDefined", constraint: c })),
-            E.chainFirst(E.fromPredicate(suit => c.suit !== suit, (): SystemValidationBidReason => ({ type: "SamePrimaryAndSecondarySuit", constraint: c }))),
-            E.map(constVoid))))))
+// const checkPass = (bid: Bid) => (force: O.Option<ConstraintForce>) =>
+//   !(bid === "Pass" && O.isSome(force))
 
-    case "SetTrump":
-      return pipe(
-        S.gets(partnershipContextA.at("We").composeLens(trumpSuitL).get),
-        S.chain(O.fold(
-          () => effectModifyS(partnershipContextA.at("We").composeLens(trumpSuitL).set(O.some(c.suit))),
-          () => ofS(E.left({ type: "TrumpSuitAlreadyDefined", constraint: c })))))
+// const checkPassS : ValidateResult =
+//   pipe(
+//     ofS(checkPass),
+//     S.ap(S.gets(bidL.get)),
+//     S.ap(S.gets(forceO.getOption)),
+//     S.chain(boolean.fold(
+//       flow(() => ofS({}),
+//         S.apS('bid', S.gets(bidL.get)),
+//         S.apS('path', S.gets(pathL.get)),
+//         S.map(({ bid, path }) =>
+//         E.left({ type: "PassWhileForcing" as const, bid, path }))),
+//       flow(constVoid, E.right, ofS))))
 
-    case "PointRange":
-      return pipe(c,
-        E.fromPredicate(c => c.min <= c.max,
-          (): SystemValidationBidReason => ({ type: "PointRangeInvalid", constraint: c })),
-        E.map(constVoid),
-        ofS)
-    case "SuitRange":
-      return pipe(c,
-        E.fromPredicate(c => c.min <= c.max,
-          (): SystemValidationBidReason => ({ type: "SuitRangeInvalid", constraint: c })),
-        E.map(constVoid),
-        ofS)
-        
-    case "SpecificShape":
-      return pipe(c.suits,
-        RR.foldMap(ord.trivial)(number.MonoidSum)(identity),
-        E.fromPredicate(n => n === 13,
-          (): SystemValidationBidReason => ({ type: "SpecificShapeInvalid", constraint: c })),
-        E.map(constVoid),
-        ofS)
-        case "AnyShape":
-      return pipe(c.counts,
-        RA.foldMap(number.MonoidSum)(identity),
-        E.fromPredicate(n => n === 13,
-          (): SystemValidationBidReason => ({ type: "AnyShapeInvalid", constraint: c })),
-        E.map(constVoid),
-        ofS)
+// const checkFinal : ValidateResult =
+//   pipe(
+//     S.gets(forceO.getOption),
+//     S.bindTo('force'),  
+//     S.apS('path', S.gets(pathL.get)),
+//     S.map(({ force, path }) => pipe(force,
+//       E.fromPredicate(O.isNone, () => ({ type: "NoBidDefinedButStillForcing", path } as const)),
+//       E.map(constVoid))))
 
-    case "Constant":
-    case "SuitComparison":
-    case "SuitHonors":
-    case "SuitTop":
-      return ofS(E.right(constVoid()))
-        
-    default:
-      return assertUnreachable(c)
-  }
-}  
-
-const resetForce = S.modify(forceL.set(O.none))
-const continueForce: typeof resetForce = S.of(constVoid())
-const updateForce = (bid: Bid) => (force: ConstraintForce) => {
-  switch (force.type) {
-    case "ForceOneRound":
-    case "Relay":
-      return resetForce
-    case "ForceGame":
-      return isGameLevel(bid) ? resetForce : continueForce
-    case "ForceSlam":
-      return isSlamLevel(bid) ? resetForce : continueForce
-    default:
-      return assertUnreachable(force)
-  }
-}
-
-const updateForceS : S.State<ValidateContext, void> =
-  pipe(
-    updateForce, ofS,
-    S.ap(S.gets(bidL.get)),
-    S.map(O.of),
-    optionT.ap(S.Apply)(S.gets(forceL.get)),
-    S.chain(O.sequence(S.Applicative)),
-    S.map(constVoid))
-
-const rotateRelativeContexts : S.State<ValidateContext, void> =
-  pipe(
-    S.sequenceArray([
-      pipe(S.gets(playersL.get), S.chain(flow(rotateRecord(relativePlayers), playersL.set, S.modify))),
-      pipe(S.gets(partnershipsL.get), S.chain(flow(rotateRecord(relativePartnerships), partnershipsL.set, S.modify)))
-    ]),
-    S.map(constVoid))
-
-const checkPass = (bid: Bid) => (force: O.Option<ConstraintForce>) =>
-  !(bid === "Pass" && O.isSome(force))
-
-const checkPassS : ValidateResult =
-  pipe(
-    ofS(checkPass),
-    S.ap(S.gets(bidL.get)),
-    S.ap(S.gets(forceO.getOption)),
-    S.chain(boolean.fold(
-      flow(() => ofS({}),
-        S.apS('bid', S.gets(bidL.get)),
-        S.apS('path', S.gets(pathL.get)),
-        S.map(({ bid, path }) =>
-        E.left({ type: "PassWhileForcing" as const, bid, path }))),
-      flow(constVoid, E.right, ofS))))
-
-const checkFinal : ValidateResult =
-  pipe(
-    S.gets(forceO.getOption),
-    S.bindTo('force'),  
-    S.apS('path', S.gets(pathL.get)),
-    S.map(({ force, path }) => pipe(force,
-      E.fromPredicate(O.isNone, () => ({ type: "NoBidDefinedButStillForcing", path } as const)),
-      E.map(constVoid))))
-
-const pathIsSound = (path: Path<ConstrainedBid>) =>
-  pipe(path,
-    S.traverseArray(info =>
-      pipe(
-        S.modify(bidL.set(info.bid)),
-        S.chain(() => checkPassS),
-        S.chain(E.traverse(S.Applicative)(() =>
-          pipe(ofS(info.constraint),
-            S.apFirst(updateForceS),
-            S.chain(validateS),
-            S.map(E.mapLeft((r): SystemValidationBidError => ({ bid: info.bid, ...r })))))),
-        S.apFirst(S.modify(pathL.modify(RA.prepend(info.bid)))),
-        S.apFirst(rotateRelativeContexts),
-        S.map(flow(
-          E.map(E.mapLeft((err): SystemValidationError => ({ ...err, path: pipe(path, RA.map(b => b.bid)) }))),
-          E.flatten)))),
-    S.map(RA.sequence(E.Applicative)),
-    eitherT.chain(S.Monad)(() => checkFinal),
-    S.evaluate(zeroValidationContext))
+// const pathIsSound = (path: Path<ConstrainedBid>) =>
+//   pipe(path,
+//     S.traverseArray(info =>
+//       pipe(
+//         S.modify(bidL.set(info.bid)),
+//         S.chain(() => checkPassS),
+//         S.chain(E.traverse(S.Applicative)(() =>
+//           pipe(ofS(info.constraint),
+//             S.apFirst(updateForceS),
+//             S.chain(validateS),
+//             S.map(E.mapLeft((r): SystemValidationBidError => ({ bid: info.bid, ...r })))))),
+//         S.apFirst(S.modify(pathL.modify(RA.prepend(info.bid)))),
+//         S.apFirst(rotateRelativeContexts),
+//         S.map(flow(
+//           E.map(E.mapLeft((err): SystemValidationError => ({ ...err, path: pipe(path, RA.map(b => b.bid)) }))),
+//           E.flatten)))),
+//     S.map(RA.sequence(E.Applicative)),
+//     eitherT.chain(S.Monad)(() => checkFinal),
+//     S.evaluate(zeroValidationContext))
 
 const forestIsSound = (tree: Forest<ConstrainedBid>) : SystemValidation =>
   pipe(tree,
     getAllLeafPaths,
-    RA.traverse(E.Applicative)(pathIsSound),
+    RA.traverse(E.Applicative)(flow(
+      pathIsSound,
+      E.mapLeft((path): SystemValidationError => ({ type: "SAT", path: path.map(b => b.bid) })))),
     E.map(constVoid))
 
 export const validateTree = (forest: Forest<ConstrainedBid>) =>

--- a/src/parse/bid.peg
+++ b/src/parse/bid.peg
@@ -31,7 +31,7 @@ Constraint :=
   | Not
   | Otherwise
   | Distribution
-  | Response
+  // | Response
   | SuitRange
   | SuitBound
   | SuitComparison
@@ -89,11 +89,11 @@ Secondary := suit=SuitSpecifier '2'
 
 SetTrump := suit=SuitSpecifier '#'
 
-Response := ForceOneRound | ForceGame | ForceSlam | Relay
-ForceOneRound := v='F1'
-ForceGame := v='FG'
-ForceSlam := v='FS'
-Relay := '->' bid=OtherBid
+// Response := ForceOneRound | ForceGame | ForceSlam | Relay
+// ForceOneRound := v='F1'
+// ForceGame := v='FG'
+// ForceSlam := v='FS'
+// Relay := '->' bid=OtherBid
 
 
 LabelDef := '\'' label=Label '\': ' constraints=ConstraintList

--- a/src/parse/bid.peg.g.ts
+++ b/src/parse/bid.peg.g.ts
@@ -28,7 +28,7 @@
 *   | Not
 *   | Otherwise
 *   | Distribution
-*   | Response
+*   // | Response
 *   | SuitRange
 *   | SuitBound
 *   | SuitComparison
@@ -74,11 +74,11 @@
 * Primary := suit=SuitSpecifier '1'
 * Secondary := suit=SuitSpecifier '2'
 * SetTrump := suit=SuitSpecifier '#'
-* Response := ForceOneRound | ForceGame | ForceSlam | Relay
-* ForceOneRound := v='F1'
-* ForceGame := v='FG'
-* ForceSlam := v='FS'
-* Relay := '->' bid=OtherBid
+* // Response := ForceOneRound | ForceGame | ForceSlam | Relay
+* // ForceOneRound := v='F1'
+* // ForceGame := v='FG'
+* // ForceSlam := v='FS'
+* // Relay := '->' bid=OtherBid
 * LabelDef := '\'' label=Label '\': ' constraints=ConstraintList
 * LabelRef := '\'' label=Label '\''
 * Label := v='[0-9a-zA-z-_]+'
@@ -140,7 +140,6 @@ export enum ASTKinds {
     Constraint_16 = "Constraint_16",
     Constraint_17 = "Constraint_17",
     Constraint_18 = "Constraint_18",
-    Constraint_19 = "Constraint_19",
     Const_1 = "Const_1",
     Const_2 = "Const_2",
     True = "True",
@@ -193,14 +192,6 @@ export enum ASTKinds {
     Primary = "Primary",
     Secondary = "Secondary",
     SetTrump = "SetTrump",
-    Response_1 = "Response_1",
-    Response_2 = "Response_2",
-    Response_3 = "Response_3",
-    Response_4 = "Response_4",
-    ForceOneRound = "ForceOneRound",
-    ForceGame = "ForceGame",
-    ForceSlam = "ForceSlam",
-    Relay = "Relay",
     LabelDef = "LabelDef",
     LabelRef = "LabelRef",
     Label = "Label",
@@ -288,26 +279,25 @@ export interface ConstraintListItem {
     kind: ASTKinds.ConstraintListItem;
     constraint: Constraint;
 }
-export type Constraint = Constraint_1 | Constraint_2 | Constraint_3 | Constraint_4 | Constraint_5 | Constraint_6 | Constraint_7 | Constraint_8 | Constraint_9 | Constraint_10 | Constraint_11 | Constraint_12 | Constraint_13 | Constraint_14 | Constraint_15 | Constraint_16 | Constraint_17 | Constraint_18 | Constraint_19;
+export type Constraint = Constraint_1 | Constraint_2 | Constraint_3 | Constraint_4 | Constraint_5 | Constraint_6 | Constraint_7 | Constraint_8 | Constraint_9 | Constraint_10 | Constraint_11 | Constraint_12 | Constraint_13 | Constraint_14 | Constraint_15 | Constraint_16 | Constraint_17 | Constraint_18;
 export type Constraint_1 = Const;
 export type Constraint_2 = Or;
 export type Constraint_3 = And;
 export type Constraint_4 = Not;
 export type Constraint_5 = Otherwise;
 export type Constraint_6 = Distribution;
-export type Constraint_7 = Response;
-export type Constraint_8 = SuitRange;
-export type Constraint_9 = SuitBound;
-export type Constraint_10 = SuitComparison;
-export type Constraint_11 = SuitHonors;
-export type Constraint_12 = SuitTop;
-export type Constraint_13 = SuitRank;
-export type Constraint_14 = SetTrump;
-export type Constraint_15 = PointRange;
-export type Constraint_16 = PointBound;
-export type Constraint_17 = OtherBid;
-export type Constraint_18 = LabelDef;
-export type Constraint_19 = LabelRef;
+export type Constraint_7 = SuitRange;
+export type Constraint_8 = SuitBound;
+export type Constraint_9 = SuitComparison;
+export type Constraint_10 = SuitHonors;
+export type Constraint_11 = SuitTop;
+export type Constraint_12 = SuitRank;
+export type Constraint_13 = SetTrump;
+export type Constraint_14 = PointRange;
+export type Constraint_15 = PointBound;
+export type Constraint_16 = OtherBid;
+export type Constraint_17 = LabelDef;
+export type Constraint_18 = LabelRef;
 export type Const = Const_1 | Const_2;
 export type Const_1 = True;
 export type Const_2 = False;
@@ -478,27 +468,6 @@ export interface Secondary {
 export interface SetTrump {
     kind: ASTKinds.SetTrump;
     suit: SuitSpecifier;
-}
-export type Response = Response_1 | Response_2 | Response_3 | Response_4;
-export type Response_1 = ForceOneRound;
-export type Response_2 = ForceGame;
-export type Response_3 = ForceSlam;
-export type Response_4 = Relay;
-export interface ForceOneRound {
-    kind: ASTKinds.ForceOneRound;
-    v: string;
-}
-export interface ForceGame {
-    kind: ASTKinds.ForceGame;
-    v: string;
-}
-export interface ForceSlam {
-    kind: ASTKinds.ForceSlam;
-    v: string;
-}
-export interface Relay {
-    kind: ASTKinds.Relay;
-    bid: OtherBid;
 }
 export interface LabelDef {
     kind: ASTKinds.LabelDef;
@@ -848,7 +817,6 @@ export class Parser {
                 () => this.matchConstraint_16($$dpth + 1, $$cr),
                 () => this.matchConstraint_17($$dpth + 1, $$cr),
                 () => this.matchConstraint_18($$dpth + 1, $$cr),
-                () => this.matchConstraint_19($$dpth + 1, $$cr),
             ]);
         };
         const $scope$pos = this.mark();
@@ -895,42 +863,39 @@ export class Parser {
         return this.matchDistribution($$dpth + 1, $$cr);
     }
     public matchConstraint_7($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_7> {
-        return this.matchResponse($$dpth + 1, $$cr);
-    }
-    public matchConstraint_8($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_8> {
         return this.matchSuitRange($$dpth + 1, $$cr);
     }
-    public matchConstraint_9($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_9> {
+    public matchConstraint_8($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_8> {
         return this.matchSuitBound($$dpth + 1, $$cr);
     }
-    public matchConstraint_10($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_10> {
+    public matchConstraint_9($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_9> {
         return this.matchSuitComparison($$dpth + 1, $$cr);
     }
-    public matchConstraint_11($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_11> {
+    public matchConstraint_10($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_10> {
         return this.matchSuitHonors($$dpth + 1, $$cr);
     }
-    public matchConstraint_12($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_12> {
+    public matchConstraint_11($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_11> {
         return this.matchSuitTop($$dpth + 1, $$cr);
     }
-    public matchConstraint_13($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_13> {
+    public matchConstraint_12($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_12> {
         return this.matchSuitRank($$dpth + 1, $$cr);
     }
-    public matchConstraint_14($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_14> {
+    public matchConstraint_13($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_13> {
         return this.matchSetTrump($$dpth + 1, $$cr);
     }
-    public matchConstraint_15($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_15> {
+    public matchConstraint_14($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_14> {
         return this.matchPointRange($$dpth + 1, $$cr);
     }
-    public matchConstraint_16($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_16> {
+    public matchConstraint_15($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_15> {
         return this.matchPointBound($$dpth + 1, $$cr);
     }
-    public matchConstraint_17($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_17> {
+    public matchConstraint_16($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_16> {
         return this.matchOtherBid($$dpth + 1, $$cr);
     }
-    public matchConstraint_18($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_18> {
+    public matchConstraint_17($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_17> {
         return this.matchLabelDef($$dpth + 1, $$cr);
     }
-    public matchConstraint_19($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_19> {
+    public matchConstraint_18($$dpth: number, $$cr?: ErrorTracker): Nullable<Constraint_18> {
         return this.matchLabelRef($$dpth + 1, $$cr);
     }
     public matchConst($$dpth: number, $$cr?: ErrorTracker): Nullable<Const> {
@@ -1502,79 +1467,6 @@ export class Parser {
                     && this.regexAccept(String.raw`(?:#)`, $$dpth + 1, $$cr) !== null
                 ) {
                     $$res = {kind: ASTKinds.SetTrump, suit: $scope$suit};
-                }
-                return $$res;
-            });
-    }
-    public matchResponse($$dpth: number, $$cr?: ErrorTracker): Nullable<Response> {
-        return this.choice<Response>([
-            () => this.matchResponse_1($$dpth + 1, $$cr),
-            () => this.matchResponse_2($$dpth + 1, $$cr),
-            () => this.matchResponse_3($$dpth + 1, $$cr),
-            () => this.matchResponse_4($$dpth + 1, $$cr),
-        ]);
-    }
-    public matchResponse_1($$dpth: number, $$cr?: ErrorTracker): Nullable<Response_1> {
-        return this.matchForceOneRound($$dpth + 1, $$cr);
-    }
-    public matchResponse_2($$dpth: number, $$cr?: ErrorTracker): Nullable<Response_2> {
-        return this.matchForceGame($$dpth + 1, $$cr);
-    }
-    public matchResponse_3($$dpth: number, $$cr?: ErrorTracker): Nullable<Response_3> {
-        return this.matchForceSlam($$dpth + 1, $$cr);
-    }
-    public matchResponse_4($$dpth: number, $$cr?: ErrorTracker): Nullable<Response_4> {
-        return this.matchRelay($$dpth + 1, $$cr);
-    }
-    public matchForceOneRound($$dpth: number, $$cr?: ErrorTracker): Nullable<ForceOneRound> {
-        return this.run<ForceOneRound>($$dpth,
-            () => {
-                let $scope$v: Nullable<string>;
-                let $$res: Nullable<ForceOneRound> = null;
-                if (true
-                    && ($scope$v = this.regexAccept(String.raw`(?:F1)`, $$dpth + 1, $$cr)) !== null
-                ) {
-                    $$res = {kind: ASTKinds.ForceOneRound, v: $scope$v};
-                }
-                return $$res;
-            });
-    }
-    public matchForceGame($$dpth: number, $$cr?: ErrorTracker): Nullable<ForceGame> {
-        return this.run<ForceGame>($$dpth,
-            () => {
-                let $scope$v: Nullable<string>;
-                let $$res: Nullable<ForceGame> = null;
-                if (true
-                    && ($scope$v = this.regexAccept(String.raw`(?:FG)`, $$dpth + 1, $$cr)) !== null
-                ) {
-                    $$res = {kind: ASTKinds.ForceGame, v: $scope$v};
-                }
-                return $$res;
-            });
-    }
-    public matchForceSlam($$dpth: number, $$cr?: ErrorTracker): Nullable<ForceSlam> {
-        return this.run<ForceSlam>($$dpth,
-            () => {
-                let $scope$v: Nullable<string>;
-                let $$res: Nullable<ForceSlam> = null;
-                if (true
-                    && ($scope$v = this.regexAccept(String.raw`(?:FS)`, $$dpth + 1, $$cr)) !== null
-                ) {
-                    $$res = {kind: ASTKinds.ForceSlam, v: $scope$v};
-                }
-                return $$res;
-            });
-    }
-    public matchRelay($$dpth: number, $$cr?: ErrorTracker): Nullable<Relay> {
-        return this.run<Relay>($$dpth,
-            () => {
-                let $scope$bid: Nullable<OtherBid>;
-                let $$res: Nullable<Relay> = null;
-                if (true
-                    && this.regexAccept(String.raw`(?:->)`, $$dpth + 1, $$cr) !== null
-                    && ($scope$bid = this.matchOtherBid($$dpth + 1, $$cr)) !== null
-                ) {
-                    $$res = {kind: ASTKinds.Relay, bid: $scope$bid};
                 }
                 return $$res;
             });

--- a/src/parse/bid.ts
+++ b/src/parse/bid.ts
@@ -182,14 +182,14 @@ export const constraint = (c: AST.Constraint) : Syntax => {
         suits: pipe(zeroSpecificShape, readonlyRecord.mapWithIndex((s, _) => c[s].value))
       })
 
-    case AST.ASTKinds.Relay:
-      return wrap({
-        type: "Relay",
-        bid: {
-          level: c.bid.level.value,
-          strain: strain(c.bid.strain)
-        }
-      })
+    // case AST.ASTKinds.Relay:
+    //   return wrap({
+    //     type: "Relay",
+    //     bid: {
+    //       level: c.bid.level.value,
+    //       strain: strain(c.bid.strain)
+    //     }
+    //   })
 
     case AST.ASTKinds.LabelDef:
       return {
@@ -210,7 +210,7 @@ export const constraint = (c: AST.Constraint) : Syntax => {
       return { type: c.kind }
     
     default:
-      return wrap({ type: c.kind })
+      return assertUnreachable(c)
   }
 }
 

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -13,7 +13,7 @@ import generator, { epics as generatorEpics } from './generator';
 import profile, { epics as profileEpics } from './profile';
 import selection, { selectHand } from './selection';
 import settings from './settings';
-import system, { selectValidConstrainedBidPaths } from './system';
+import system, { epics as systemEpics, selectValidConstrainedBidPaths } from './system';
 
 const reducers = {
   system,
@@ -26,7 +26,8 @@ export default reducers
 
 export const rootEpic = combineEpics<AnyAction, AnyAction, RootState>(
   ...generatorEpics,
-  ...profileEpics
+  ...profileEpics,
+  ...systemEpics
 )
 
 interface BidResult {

--- a/src/reducers/system.ts
+++ b/src/reducers/system.ts
@@ -17,7 +17,7 @@ import { get } from '../lib/object';
 import { Bid, eqBid } from '../model/bridge';
 import { chainCollectedErrors, collectErrors, flatten, ForestWithErrors, getAllLeafPaths, getPathForest, getPathUpTo, Path, withImplicitPasses } from '../model/system';
 import { ExpandError, expandForest, SyntacticBid } from '../model/system/expander';
-import { SystemValidationError, validateTree } from '../model/system/validation';
+import { SystemValidationError, validateForest } from '../model/system/validation';
 import { decodeBid } from '../parse';
 import { observeValidation } from '../workers';
 
@@ -192,7 +192,7 @@ export const selectCompleteConstraintForest = memoize(
   flow(selectExpandedConstraintForest,
     chainCollectedErrors(bidForest => pipe(
       bidForest,
-      validateTree,
+      validateForest,
       TH.bimap(
         (error): ReadonlyArray<SystemError> => RA.of({ type: "Validation", error }),
         () => bidForest)))))

--- a/src/services/idb.ts
+++ b/src/services/idb.ts
@@ -1,6 +1,6 @@
 import { either, option as O, readonlyArray as RA, readonlyRecord as RR, semigroup, string, task, taskEither as TE } from 'fp-ts';
 import { flow, pipe } from 'fp-ts/lib/function';
-import { DBSchema, deleteDB, IDBPDatabase, IndexNames, openDB } from 'idb';
+import { DBSchema, deleteDB, IDBPDatabase, IndexKey, IndexNames, openDB, StoreNames } from 'idb';
 import { UuidTool } from 'uuid-tool';
 
 import { ConstrainedBidPathHash, GenerationId } from '../model/job';
@@ -100,7 +100,7 @@ export const insertSatisfies = (generationId: GenerationId, hash: ConstrainedBid
     TE.chain(({ tran }) => TE.tryCatch(() => tran.done, (): DbError => "CommitRejected")))
 
 const getByIndex = <I extends IndexNames<DealDB, 'deal'>>(idx: I) => (id: string) =>
-  TE.tryCatchK((db: IDBPDatabase<DealDB>) => db.getAllFromIndex('deal', idx, id), (): DbError => "SelectError")
+  TE.tryCatchK((db: IDBPDatabase<DealDB>) => db.getAllFromIndex('deal', idx, id as any), (): DbError => "SelectError")
 
 export const getDealsByGenerationId = (generationId: GenerationId) =>
   pipe(getDb,

--- a/src/workers/custom.d.ts
+++ b/src/workers/custom.d.ts
@@ -46,7 +46,7 @@ declare module 'comlink-loader!./sat.worker' {
 
   class SATWorker extends Worker {
     constructor();
-    getPathIsSound(path: Path<ConstrainedBid>): Promise<Either<Path<Bid>, void>>;
+    getPathIsSound(path: Path<ConstrainedBid>): Promise<Either<ReadonlyArray<Bid>, void>>;
   }
   export = SATWorker;
 }

--- a/src/workers/custom.d.ts
+++ b/src/workers/custom.d.ts
@@ -37,3 +37,16 @@ declare module 'comlink-loader!./dds.worker' {
   }
   export = DDSWorker;
 }
+
+declare module 'comlink-loader!./sat.worker' {
+  type Either<E, A> = import ('fp-ts').either.Either<E, A>
+  type Path<A> = import ("../model/system").Path<A>
+  type ConstrainedBid = import ("../model/system/core").ConstrainedBid
+  type Bid = import ("../model/bridge").Bid
+
+  class SATWorker extends Worker {
+    constructor();
+    getPathIsSound(path: Path<ConstrainedBid>): Promise<Either<Path<Bid>, void>>;
+  }
+  export = SATWorker;
+}

--- a/src/workers/dds.worker.ts
+++ b/src/workers/dds.worker.ts
@@ -40,9 +40,9 @@ export const getResult = (board: SerializedBoard) : Promise<either.Either<string
     (results): DoubleDummyResult => ({ board, results }),
     TE.of,
     TE.chainFirst(flow(readonlyArray.of, insertSolutions)),
-    TE.chainFirst(flow(
-      (s): DealWithSolution => [
-        pipe(s.board.deal, serializedDealL.reverseGet),
-        pipe(s.results, transpose, O.of)
-      ], readonlyArray.of, putDeals)))
-  ()
+    // TE.chainFirst(flow(
+    //   (s): DealWithSolution => [
+    //     pipe(s.board.deal, serializedDealL.reverseGet),
+    //     pipe(s.results, transpose, O.of)
+    //   ], readonlyArray.of, putDeals))
+  )()

--- a/src/workers/deal.worker.ts
+++ b/src/workers/deal.worker.ts
@@ -12,5 +12,5 @@ export const genDeals = (count: number, generationId: GenerationId) : Promise<ei
   pipe(
     taskEither.of(readonlyArray.makeBy(count, flow(newDeck, deal, serializedDealL.get))),
     taskEither.chainFirst(insertDeals(generationId)),
-    taskEither.chainFirst(flow(readonlyArray.map(serializedDealL.reverseGet), postDeals)))
-  ()
+    // taskEither.chainFirst(flow(readonlyArray.map(serializedDealL.reverseGet), postDeals))
+  )()

--- a/src/workers/index.ts
+++ b/src/workers/index.ts
@@ -4,17 +4,17 @@ import DDSWorker from 'comlink-loader!./dds.worker'; // inline loader
 import DealWorker from 'comlink-loader!./deal.worker'; // inline loader
 import SATWorker from 'comlink-loader!./sat.worker';
 import SatisfiesWorker from 'comlink-loader!./satisfies.worker';
-import { either as E, readonlyArray as RA, readonlyNonEmptyArray as RNEA, readonlyTuple, taskEither } from 'fp-ts';
+import { either as E, readonlyArray as RA, readonlyNonEmptyArray as RNEA, taskEither } from 'fp-ts';
 import { observable as Ob, observableEither as ObE } from 'fp-ts-rxjs';
 import { pipe } from 'fp-ts/lib/function';
 import { from, groupBy, Observable } from 'rxjs';
 
 import { get } from '../lib/object';
 import pool from '../lib/pool';
-import { Bid, eqBid, makeBoard } from '../model/bridge';
+import { Bid, makeBoard } from '../model/bridge';
 import { GenerationId, Solution } from '../model/job';
 import { SerializedBidPath, serializedBidPathL, serializedBoardL, SerializedDeal, serializedDealL } from '../model/serialization';
-import { Forest, getAllLeafPaths, Path, Paths } from '../model/system';
+import { Path, Paths } from '../model/system';
 import { ConstrainedBid } from '../model/system/core';
 import { getBatchIdsByGenerationId } from '../services/idb';
 
@@ -64,9 +64,8 @@ export const observeSolutions = (deals: ReadonlyArray<SerializedDeal>) =>
     })))
 
 type ValidationResult = readonly [Path<Bid>, boolean]
-export const observeValidation = (forest: Forest<ConstrainedBid>) : Observable<ValidationResult> =>
-  pipe(forest,
-    getAllLeafPaths,
+export const observeValidation = (paths: ReadonlyArray<Path<ConstrainedBid>>) : Observable<ValidationResult> =>
+  pipe(paths,
     pool(() => new SATWorker(), w => async p =>
       pipe(await w.getPathIsSound(p),
         E.fold(p0 => p0.length, () => p.length),

--- a/src/workers/sat.worker.ts
+++ b/src/workers/sat.worker.ts
@@ -1,0 +1,9 @@
+import { either as E } from 'fp-ts';
+
+import { Bid } from '../model/bridge';
+import { Path } from '../model/system';
+import { ConstrainedBid } from '../model/system/core';
+import { pathIsSound } from '../model/system/sat';
+
+export const getPathIsSound = (path: Path<ConstrainedBid>): Promise<E.Either<Path<Bid>, void>> =>
+  Promise.resolve(pathIsSound(path))

--- a/typings/logic-solver.d.ts
+++ b/typings/logic-solver.d.ts
@@ -1,0 +1,61 @@
+declare module 'logic-solver' {
+  type Term = number | string
+  const FALSE: Term
+  const TRUE: Term
+  function isTerm(value: any): value is Term
+  function isNameTerm(value: any): value is string
+  function isNumTerm(value: any): value is number
+
+  type Operand = Term | Formula
+  type Operands = Operand | ArrayOfOperands
+  interface ArrayOfOperands extends Array<Operands> {}
+
+  class Solver {
+    constructor()
+    toNameTerm(term: Term): string
+    toNumTerm(term: Term, noCreate?: boolean): number
+    require(...args: Operands[]): void
+    forbid(...args: Operands[]): void
+    solve(): Solution | null
+    solveAssuming(assumption: Operand): Solution | null
+    minimizeWeightedSum(solution: Solution, formulas: Operand[], weights: number[] | number): Solution | null
+    maximizeWeightedSum(solution: Solution, formulas: Operand[], weights: number[] | number): Solution | null
+  }
+
+  interface Formula {}
+  function isFormula(value: any): value is Formula
+  function not(operand: Operand): Formula
+  function or(...operands: Operands[]): Formula
+  function and(...operands: Operands[]): Formula
+  function xor(...operands: Operands[]): Formula
+  function implies(operand1: Operand, operand2: Operand): Formula
+  function equiv(operand1: Operand, operand2: Operand): Formula
+  function exactlyOne(...operands: Operands[]): Formula
+  function atMostOne(...operands: Operands[]): Formula
+
+  function disablingAssertions<A>(func: () => A): A
+
+  interface Solution {
+    getMap(): Record<string, boolean>
+    getTrueVars(): string[]
+    evaluate(expression: Term | Formula): boolean
+    evaluate(expression: Bits): number
+    getFormula(): Formula
+    getWeightedSum(formula: (Operand | Bits)[], weights: number[]): number
+    ignoreUnknownVariables(): void
+  }
+
+  class Bits {
+    constructor(formulas: Operand[])
+  }
+  function isBits(value: any): value is Bits
+  function constantBits(wholeNumber: number): Bits
+  function variableBits(baseName: string, N: number): Bits
+  function equalBits(bits1: Bits, bits2: Bits): Formula
+  function lessThan(bits1: Bits, bits2: Bits): Formula
+  function lessThanOrEqual(bits1: Bits, bits2: Bits): Formula
+  function greaterThan(bits1: Bits, bits2: Bits): Formula
+  function greaterThanOrEqual(bits1: Bits, bits2: Bits): Formula
+  function sum(...operands: (Operand | Bits)[]): Bits
+  function weightedSum(formulas: (Operand | Bits)[], weights: number[] | number): Bits
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -11361,10 +11361,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.5.0-beta:
-  version "4.5.0-beta"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.0-beta.tgz#f2e2724d93c35e7a0d0d1e55a22d1e4efb2181c7"
-  integrity sha512-7PvWhki2lwukaR9osVhFnNzxaE4LM+gC94dlwcvS+Tqz8+U65va7FbKo02bT+/MFlnMPM8bsPUXvHiMD/Mg3Jg==
+typescript@^4.5.0:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 typical@^2.6.1:
   version "2.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7455,6 +7455,13 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+logic-solver@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/logic-solver/-/logic-solver-2.0.1.tgz#e9fa47002eb5d8cda7616d41639b97552eb674be"
+  integrity sha1-6fpHAC612M2nYW1BY5uXVS62dL4=
+  dependencies:
+    underscore "^1.7.0"
+
 loglevel@^1.6.8:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
@@ -11378,6 +11385,11 @@ unbox-primitive@^1.0.1:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+underscore@^1.7.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 unicode-canonical-property-names-ecmascript@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1524,6 +1524,13 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@nll/datum@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@nll/datum/-/datum-3.5.0.tgz#289e97333a6c1714d83fa99c79214f3e85fd9e92"
+  integrity sha512-qNdzqbm8O8DGef5UGJUnMkFmg0aBzBbnMs1dxVGchIJ6nz9iypp6BBwniCXMM4ltkxLRBj3dkv/FcvReGVRZgA==
+  dependencies:
+    fp-ts "^2.0.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -5511,6 +5518,11 @@ fp-ts-rxjs@^0.6.15:
   version "0.6.15"
   resolved "https://registry.yarnpkg.com/fp-ts-rxjs/-/fp-ts-rxjs-0.6.15.tgz#4c53ecaf5e18a82c94e4a43a4cf8148978ef9e6c"
   integrity sha512-5fD4a/439l0aUkSkPq7xnznXYsD7YwGyYANO3v6dkkZJTta36et3bNJ2tzq28UcVR6bS9nTDbP7kMjgQqFFxYQ==
+
+fp-ts@^2.0.0:
+  version "2.11.5"
+  resolved "https://registry.yarnpkg.com/fp-ts/-/fp-ts-2.11.5.tgz#97cceb26655b1452d7088d6fb0864f84cceffbe4"
+  integrity sha512-OqlwJq1BdpB83BZXTqI+dNcA6uYk6qk4u9Cgnt64Y+XS7dwdbp/mobx8S2KXf2AXH+scNmA/UVK3SEFHR3vHZA==
 
 fp-ts@^2.11.4:
   version "2.11.4"


### PR DESCRIPTION
Replaces handmade validation algorithm with one that uses a SAT-based constraint solver. Validation is performed by path and done in the background, though it is currently very expensive and runs too often.

Server write-through is also temporarily disabled until the server is brought back online or moved to the cloud.